### PR TITLE
Adding CODEOWNERS for Auto Assigned Reviews

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @benroe @aatmmr


### PR DESCRIPTION
This pull request includes a single change to the `CODEOWNERS` file, designating `@benroe` and `@aatmmr` as code owners for all files in the repository. With this setting, both users will be auto assigned to approve PR's.

* <a href="diffhunk://#diff-fcf14c4b7b34fe7a11916195871ae66a59be87a395f28db73e345ebdc828085bR1">`CODEOWNERS`</a>: Updated the `CODEOWNERS` file to designate `@benroe` and `@aatmmr` as code owners for all files in the repository.