### PR TITLE
Updating Repository URLs after Repo was moved to new Organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ View the pages on [Keebfolio.netlify.app](https://keebfolio.netlify.app/) or Git
 ## Contributing
 
 Contributions are welcome!  
-To add content, edit the Markdown file in the [src/pages/en](src/pages/en/) folder and open a [Pull Request](https://help.github.com/en/articles/about-pull-requests). You can also open a new [Issue](https://github.com/BenRoe/awesome-mechanical-keyboard/issues).  
+To add content, edit the Markdown file in the [src/pages/en](src/pages/en/) folder and open a [Pull Request](https://help.github.com/en/articles/about-pull-requests). You can also open a new [Issue](https://github.com/Keycapsss/awesome-mechanical-keyboard/issues).  
 Please use this [commit message conventions](https://gist.github.com/qoomon/5dfcdf8eec66a051ecd85625518cfd13).
 
 The project uses [Astro](https://astro.build) as a Static Site Generator.

--- a/src/components/Footer/AvatarList.astro
+++ b/src/components/Footer/AvatarList.astro
@@ -5,8 +5,8 @@ type Props = {
 };
 const { path } = Astro.props as Props;
 const resolvedPath = `examples/docs/${path}`;
-const url = `https://api.github.com/repos/BenRoe/awesome-mechanical-keyboard/commits?path=${resolvedPath}`;
-const commitsURL = `https://github.com/BenRoe/awesome-mechanical-keyboard/commits/main/${resolvedPath}`;
+const url = `https://api.github.com/repos/keycapsss/awesome-mechanical-keyboard/commits/?path=${path}`;
+const commitsURL = `https://github.com/keycapsss/awesome-mechanical-keyboard/commits/master/${path}`;
 
 type Commit = {
 	author: {
@@ -17,6 +17,8 @@ type Commit = {
 
 async function getCommits(url: string) {
 	try {
+		console.log(url);
+
 		const token = import.meta.env.SNOWPACK_PUBLIC_GITHUB_TOKEN ?? 'hello';
 		if (!token) {
 			throw new Error(

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@ export const SITE = {
 
 export const OPEN_GRAPH = {
 	image: {
-		src: 'https://github.com/BenRoe/awesome-mechanical-keyboard/blob/master/public/default-og-image.png?raw=true',
+		src: 'https://github.com/Keycapsss/awesome-mechanical-keyboard/blob/master/public/default-og-image.png?raw=true',
 		alt:
 			'astro logo on a starry expanse of space,' +
 			' with a purple saturn-like planet floating in the right foreground',
@@ -30,9 +30,9 @@ export const KNOWN_LANGUAGES = {
 } as const;
 export const KNOWN_LANGUAGE_CODES = Object.values(KNOWN_LANGUAGES);
 
-export const GITHUB_EDIT_URL = `https://github.com/BenRoe/awesome-mechanical-keyboard`;
+export const GITHUB_EDIT_URL = `https://github.com/Keycapsss/awesome-mechanical-keyboard/blob/master`;
 
-export const COMMUNITY_INVITE_URL = `https://github.com/BenRoe/awesome-mechanical-keyboard/discussions`;
+export const COMMUNITY_INVITE_URL = `https://github.com/Keycapsss/awesome-mechanical-keyboard/discussions`;
 
 // See "Algolia" section of the README for more information.
 export const ALGOLIA = {


### PR DESCRIPTION
This pull request updates various URLs and links in the codebase to point to the correct repositories. The most significant changes include updating the GitHub URLs in the `src/config.ts` file, updating the links in the "Contributing" section of the `README.md` file, and updating the `url` and `commitsURL` constants in the `src/components/Footer/AvatarList.astro` file.

Main URL and link updates:

* [`src/config.ts`](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012L33-R35): Updated the GitHub URLs in the `src/config.ts` file to point to the repository of `Keycapsss/awesome-mechanical-keyboard` instead of `BenRoe/awesome-mechanical-keyboard`. [[1]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012L33-R35) [[2]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012L9-R9)
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R20): Updated the links in the "Contributing" section of the `README.md` file to point to the correct repository.

Component updates:

* [`src/components/Footer/AvatarList.astro`](diffhunk://#diff-e4a9be1a4129434d63794834946321596b0ae6271967d01feea1190546bc39b0R20-R21): Added a `console.log(url)` statement for debugging purposes and updated the `url` and `commitsURL` constants to point to different repositories. [[1]](diffhunk://#diff-e4a9be1a4129434d63794834946321596b0ae6271967d01feea1190546bc39b0R20-R21) [[2]](diffhunk://#diff-e4a9be1a4129434d63794834946321596b0ae6271967d01feea1190546bc39b0L8-R9)

Fixes #161 